### PR TITLE
Make linking mode classes configurable

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -33,6 +33,24 @@ class Link extends DataObject
     private static $table_name = 'Link';
 
     /**
+     * @config
+     * @var string
+     */
+    private static $linking_mode_default = 'link';
+
+    /**
+     * @config
+     * @var string
+     */
+    private static $linking_mode_current = 'current';
+
+    /**
+     * @config
+     * @var string
+     */
+    private static $linking_mode_section = 'section';
+
+    /**
      * Database fields
      * @var array
      */
@@ -609,11 +627,11 @@ class Link extends DataObject
     public function LinkingMode()
     {
         if ($this->isCurrent()) {
-            return 'current';
+            return static::config()->get('linking_mode_current');
         } elseif ($this->isSection()) {
-            return 'section';
+            return static::config()->get('linking_mode_section');
         } else {
-            return 'link';
+            return static::config()->get('linking_mode_default');
         }
     }
 

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -603,7 +603,9 @@ class Link extends DataObject
     {
         $isCurrent = null;
         $this->extend('UpdateLinkOrCurrent', $isCurrent);
-        return $isCurrent ? 'current' : 'link';
+        return $isCurrent
+            ? static::config()->get('linking_mode_current')
+            : static::config()->get('linking_mode_default');
     }
 
     /**
@@ -615,7 +617,9 @@ class Link extends DataObject
     {
         $isSection = null;
         $this->extend('UpdateLinkOrSection', $isSection);
-        return $isSection ? 'section' : 'link';
+        return $isSection
+            ? static::config()->get('linking_mode_section')
+            : static::config()->get('linking_mode_default');
     }
 
     /**


### PR DESCRIPTION
It may be desirable to override the default linking mode classes without incurring the performance hit of adding an extension and implementing `updateClasses()`. To this end, I've made the linking mode classes configurable, with the defaults set to the current (default SS) values.