### PR TITLE
Add canView/Edit/Delete/Create, simplify template resolution logic, add PHPDoc

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -314,13 +314,13 @@ class Link extends DataObject
     }
 
     /**
-     * If the title is empty, set it to getLinkURL()
-     * @return string
+     * If the title is empty, set it to default
      */
-    public function onAfterWrite()
+    public function onBeforeWrite()
     {
-        parent::onAfterWrite();
-        if (!$this->Title) {
+        parent::onBeforeWrite();
+
+        if (empty($this->Title)) {
             switch ($this->Type) {
                 case 'URL':
                 case 'Email':
@@ -338,8 +338,6 @@ class Link extends DataObject
                     }
                     break;
             }
-
-            $this->write();
         }
     }
 

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -683,4 +683,41 @@ class Link extends DataObject
     {
         return $this->forTemplate();
     }
+
+    /**
+     * @param \SilverStripe\Security\Member|null $member
+     * @return bool
+     */
+    public function canView($member = null)
+    {
+        return true;
+    }
+
+    /**
+     * @param \SilverStripe\Security\Member|null $member
+     * @return bool
+     */
+    public function canEdit($member = null)
+    {
+        return true;
+    }
+
+    /**
+     * @param \SilverStripe\Security\Member|null $member
+     * @return bool
+     */
+    public function canDelete($member = null)
+    {
+        return true;
+    }
+
+    /**
+     * @param \SilverStripe\Security\Member|null $member
+     * @param array $context
+     * @return bool
+     */
+    public function canCreate($member = null, $context = [])
+    {
+        return true;
+    }
 }

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -529,7 +529,7 @@ class Link extends DataObject
      */
     public function getTargetAttr()
     {
-        return $this->OpenInNewWindow ? " target='_blank'" : null;
+        return $this->OpenInNewWindow ? " target='_blank' rel='noopener'" : null;
     }
 
     /**

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -2,7 +2,6 @@
 
 namespace gorriecoe\Link\Models;
 
-use InvalidArgumentException;
 use SilverStripe\Assets\File;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\OptionsetField;
@@ -660,25 +659,15 @@ class Link extends DataObject
     }
 
     /**
-     * Returns the base class without namespacing
-     * @param  string $class
-     * @return string
-     */
-    public function baseClassName($class)
-    {
-        $class = explode('\\', $class);
-        return array_pop($class);
-    }
-
-    /**
      * Renders an HTML anchor attribute for this link
-     * @return HTML
+     * @return \SilverStripe\ORM\FieldType\DBHTMLText
      */
     public function forTemplate()
     {
         $link = '';
         if ($this->LinkURL) {
-            $link = $this->renderWith($this->RenderTemplates);
+            $templateSuffix = $this->style ? '_' . $this->style : '';
+            $link = $this->renderWith($this->getViewerTemplates($templateSuffix));
         }
         $this->extend('updateTemplate', $link);
         return $link;
@@ -693,33 +682,5 @@ class Link extends DataObject
     public function getLayout()
     {
         return $this->forTemplate();
-    }
-
-    /**
-     * Returns a list of rendering templates
-     * @return array
-     */
-    public function getRenderTemplates()
-    {
-        $ClassName = $this->ClassName;
-
-        if (is_object($ClassName)) $ClassName = get_class($ClassName);
-
-        if (!is_subclass_of($ClassName, DataObject::class)) {
-            throw new InvalidArgumentException($ClassName . ' is not a subclass of DataObject');
-        }
-
-        $templates = [];
-        while ($next = get_parent_class($ClassName)) {
-            $baseClassName = $this->baseClassName($ClassName);
-            if ($this->style) {
-                $templates[] = $baseClassName . '_' . $this->style;
-            }
-            $templates[] = $baseClassName;
-            if ($next == DataObject::class) {
-                return $templates;
-            }
-            $ClassName = $next;
-        }
     }
 }

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -559,7 +559,7 @@ class Link extends DataObject
     public function getCurrentPage()
     {
         $currentPage = Director::get_current_page();
-        if ($currentPage instanceof ContentController) {
+        if (get_class($currentPage) === 'SilverStripe\CMS\Controllers\ContentController') {
             $currentPage = $currentPage->data();
         }
         return $currentPage;

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -13,8 +13,9 @@ use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBBoolean;
+use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\ValidationResult;
-use SilverStripe\Core\Convert;
 use SilverStripe\Control\Director;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
 
@@ -23,6 +24,17 @@ use UncleCheese\DisplayLogic\Forms\Wrapper;
  *
  * @package silverstripe
  * @subpackage silverstripe-link
+ *
+ * @property string Title
+ * @property string Type
+ * @property string URL
+ * @property string Email
+ * @property string Phone
+ * @property boolean OpenInNewWindow
+ * @property string Template
+ * @property int FileID
+ *
+ * @method File|null File()
  */
 class Link extends DataObject
 {
@@ -55,13 +67,13 @@ class Link extends DataObject
      * @var array
      */
     private static $db = [
-        'Title' => 'Varchar(255)',
-        'Type' => 'Varchar(50)',
-        'URL' => 'Varchar(255)',
-        'Email' => 'Varchar(255)',
-        'Phone' => 'Varchar(30)',
-        'OpenInNewWindow' => 'Boolean',
-        'Template' => 'Varchar(255)'
+        'Title' => DBVarchar::class,
+        'Type' => DBVarchar::class . '(50)',
+        'URL' => DBVarchar::class,
+        'Email' => DBVarchar::class,
+        'Phone' => DBVarchar::class . '(30)',
+        'OpenInNewWindow' => DBBoolean::class,
+        'Template' => DBVarchar::class,
     ];
 
     /**


### PR DESCRIPTION
- Added PHPDoc for a lot of the `DataObject` fields
- Changed the default title logic from `onAfterWrite` to `onBeforeWrite` to remove double writing
- Fixed `instanceof ContentController` referencing a class that isn't imported
- Added `canView/canEdit/canDelete/canCreate` so non-`ADMIN` permission users can see/edit links. My thinking behind this is that Links will be tied to other objects that should control the permissions more restrictively as necessary, and all editors of those objects need to be able to see/edit links.
- Replaced the `getRenderTemplates` method with a call to `DataObject->getViewerTemplates`, which has the same behaviour
- Added `rel='noopener'` into `TargetAttr` for security - not having `rel=noopener` with `target=_blank` is a big security risk which users may not necessarily be aware of. While overriding the rel attribute like this is not ideal, it is preferable to be secure by default. See ` https://mathiasbynens.github.io/rel-noopener/` for more details.

If this is accepted, could you please tag a release as we would like to use this functionality in our project.