### PR TITLE
FIX: Disallow linking to folders by default.

### DIFF
--- a/docs/en/link-types.md
+++ b/docs/en/link-types.md
@@ -27,6 +27,16 @@ gorriecoe\Link\Models\Link:
     - SiteTree
 ```
 
+## Allow linking to folders
+
+By default, when the type is set to "File", folders cannot be selected.
+If you want to be able to link to folders, add the following in your site config.yml file:
+
+```yaml
+gorriecoe\Link\Models\Link:
+  link_to_folders: true
+```
+
 ## Adding custom link types
 
 To add custom link types refer to [Adding custom link types](extending#adding-custom-link-types)

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -20,6 +20,7 @@ use SilverStripe\CMS\Controllers\ContentController;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\Assets\Folder;
 
 /**
  * Link
@@ -138,6 +139,13 @@ class Link extends DataObject implements
     private static $linking_mode_section = 'section';
 
     /**
+     * If false, when Type is "File", folders in the TreeDropdownField will not be selectable.
+     * @config
+     * @var boolean
+     */
+    private static $link_to_folders = false;
+
+    /**
      * Provides a quick way to define additional methods for provideGraphQLScaffolding as Fields
      * @return Array
      */
@@ -223,7 +231,7 @@ class Link extends DataObject implements
             )
             ->setValue('URL'),
             Wrapper::create(
-                TreeDropdownField::create(
+                $fileDropdown = TreeDropdownField::create(
                     'FileID',
                     _t(__CLASS__ . '.FILE', 'File'),
                     File::class,
@@ -261,6 +269,13 @@ class Link extends DataObject implements
             ->orIf()->isEqualTo('File')
             ->orIf()->isEqualTo('SiteTree')->end()
         ];
+
+        // Disable folders in dropdown if linking to folders is not allowed.
+        if (!$this->config()->get('link_to_folders')) {
+            $fileDropdown->setDisableFunction(function ($item) {
+                return is_a($item, Folder::class);
+            });
+        }
 
         $this->extend('updateCMSMainFields', $fields);
 


### PR DESCRIPTION
Currently folders can be linked to when the link type is set to "File". There is no native way to avoid that. This was raised in #14 

With this PR folders cannot be linked to by default, though this can be allowed through .yml configuration as documented in docs/en/link-types.md

Note that this is potentially a breaking change (anyone who is currently _intentionally_ linking to folders will find they are no longer able to without updating their yml configuration).