### PR TITLE
Update URL field from Varchar to Text

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -44,7 +44,7 @@ class Link extends DataObject implements
     private static $db = [
         'Title' => 'Varchar',
         'Type' => 'Varchar(50)',
-        'URL' => 'Varchar',
+        'URL' => 'Text',
         'Email' => 'Varchar',
         'Phone' => 'Varchar(30)',
         'OpenInNewWindow' => 'Boolean',


### PR DESCRIPTION
By default, `Varchar` field types without defined length fallback to 255 characters. Some URLs may be longer, especially when they contain e.g. a proxy endpoint or similar, encoded attributes or other URL encoded data that might be a valid part of the URL.

This change updates the field type to Text to cater for longer URLs. `Text` is still variable length so shouldn't have too big an impact on storage needs within the database.