### PR TITLE
NEW: GraphQL 4 compat

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -16,14 +16,24 @@ SilverStripe\CMS\Model\SiteTree:
     - gorriecoe\Link\Extensions\SiteTreeLink
 ---
 Only:
-  moduleexists: silverstripe/graphql
+  classexists: SilverStripe\GraphQL\Manager
 ---
-SilverStripe\GraphQL\Controller:
-  schema:
-    types:
-      link: gorriecoe\Link\GraphQL\LinkTypeCreator
-    queries:
-      link: gorriecoe\Link\GraphQL\LinkQueryCreator
-      links: gorriecoe\Link\GraphQL\LinksQueryCreator
-    scaffolding_providers:
-      - gorriecoe\Link\Models\Link
+SilverStripe\GraphQL\Manager:
+  schemas:
+    default:
+      types:
+        link: gorriecoe\Link\GraphQL\LinkTypeCreator
+      queries:
+        link: gorriecoe\Link\GraphQL\LinkQueryCreator
+        links: gorriecoe\Link\GraphQL\LinksQueryCreator
+      scaffolding_providers:
+        - gorriecoe\Link\GraphQL\ScaffoldingProvider
+---
+Only:
+  classexists: SilverStripe\GraphQL\Schema\Schema
+---
+SilverStripe\GraphQL\Schema\Schema:
+  schemas:
+    default:
+      src:
+        - 'gorriecoe/silverstripe-link: _graphql'

--- a/_graphql/models.yml
+++ b/_graphql/models.yml
@@ -1,0 +1,7 @@
+gorriecoe\Link\Models\Link:
+  fields:
+    '*': true
+    linkURL: String
+    layout: String
+    template: String
+  operations: '*'

--- a/src/graphql/LinkQueryCreator.php
+++ b/src/graphql/LinkQueryCreator.php
@@ -8,6 +8,9 @@ use SilverStripe\GraphQL\OperationResolver;
 use SilverStripe\GraphQL\QueryCreator;
 use gorriecoe\Link\Models\Link;
 
+if (!class_exists(QueryCreator::class)) {
+    return;
+}
 /**
  * LinkQueryCreator
  *

--- a/src/graphql/LinkTypeCreator.php
+++ b/src/graphql/LinkTypeCreator.php
@@ -6,6 +6,10 @@ use GraphQL\Type\Definition\Type;
 use SilverStripe\GraphQL\TypeCreator;
 use SilverStripe\GraphQL\Pagination\Connection;
 
+if (!class_exists(TypeCreator::class)) {
+    return;
+}
+
 /**
  * LinkTypeCreator
  *

--- a/src/graphql/LinksQueryCreator.php
+++ b/src/graphql/LinksQueryCreator.php
@@ -8,6 +8,10 @@ use SilverStripe\GraphQL\OperationResolver;
 use SilverStripe\GraphQL\QueryCreator;
 use gorriecoe\Link\Models\Link;
 
+if (!class_exists(QueryCreator::class)) {
+    return;
+}
+
 /**
  * LinksQueryCreator
  *

--- a/src/graphql/ScaffoldingProvider.php
+++ b/src/graphql/ScaffoldingProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace gorriecoe\Link\GraphQL;
+
+use gorriecoe\Link\Models\Link;
+use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider as ScaffoldingProviderInterface;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+
+if (!interface_exists(ScaffoldingProviderInterface::class)) {
+    return;
+}
+
+class ScaffoldingProvider implements ScaffoldingProviderInterface
+{
+    public function provideGraphQLScaffolding(SchemaScaffolder $scaffolder)
+    {
+        $sng = Link::singleton();
+        $type = $scaffolder->type($sng->ClassName);
+
+        $type->addAllFields()
+            ->addFields($sng->gqlFields())
+            ->operation(SchemaScaffolder::READ)
+            ->setName('readLinks')
+            ->setUsePagination(false)
+            ->end()
+            ->operation(SchemaScaffolder::READ_ONE)
+            ->setName('readOneLink')
+            ->end()
+            ->operation(SchemaScaffolder::CREATE)
+            ->setName('createLink')
+            ->end()
+            ->operation(SchemaScaffolder::UPDATE)
+            ->setName('updateLink')
+            ->end()
+            ->operation(SchemaScaffolder::DELETE)
+            ->setName('deleteLink')
+            ->end()
+            ->end();
+        foreach ($sng->gqlNestedQueries() as $query => $paginated) {
+            $type->nestedQuery($query)
+                ->setUsePagination($paginated)
+                ->end();
+        }
+        return $scaffolder;
+    }
+
+
+}

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -15,11 +15,8 @@ use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Control\Director;
-use SilverStripe\View\SSViewer;
 use SilverStripe\CMS\Controllers\ContentController;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
-use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
 use SilverStripe\Assets\Folder;
 
 /**
@@ -28,8 +25,7 @@ use SilverStripe\Assets\Folder;
  * @package silverstripe
  * @subpackage silverstripe-link
  */
-class Link extends DataObject implements
-    ScaffoldingProvider
+class Link extends DataObject
 {
     /**
      * Defines the database table name
@@ -393,37 +389,6 @@ class Link extends DataObject implements
                     break;
             }
         }
-    }
-
-    public function provideGraphQLScaffolding(SchemaScaffolder $scaffolder)
-    {
-        $type = $scaffolder->type($this->ClassName);
-
-        $type->addAllFields()
-            ->addFields($this->gqlFields())
-            ->operation(SchemaScaffolder::READ)
-                ->setName('readLinks')
-                ->setUsePagination(false)
-                ->end()
-            ->operation(SchemaScaffolder::READ_ONE)
-                ->setName('readOneLink')
-                ->end()
-            ->operation(SchemaScaffolder::CREATE)
-                ->setName('createLink')
-                ->end()
-            ->operation(SchemaScaffolder::UPDATE)
-                ->setName('updateLink')
-                ->end()
-            ->operation(SchemaScaffolder::DELETE)
-                ->setName('deleteLink')
-                ->end()
-            ->end();
-        foreach ($this->gqlNestedQueries() as $query => $paginated) {
-            $type->nestedQuery($query)
-                ->setUsePagination($paginated)
-                ->end();
-        }
-        return $scaffolder;
     }
 
     /**


### PR DESCRIPTION
Backward compatible with GraphQL 3.

Relies on pure scaffolding features of GraphQL 4, e.g. `readOneLink`, `readLinks`. I didn't see anything in the type definitions or resolvers that was beyond the capabilities of the standard graphql models, so the only breaking changes are the names of the queries, the casing of the field names, and the shape of the filter argument. 